### PR TITLE
S3 without rs creds

### DIFF
--- a/locopy/locopy.py
+++ b/locopy/locopy.py
@@ -253,7 +253,10 @@ class Cmd(object):
         bool
             True if conn and cursor are not ``None``, False otherwise.
         """
-        return self.conn is not None and self.cursor is not None
+        try:
+            return self.conn is not None and self.cursor is not None
+        except:
+            return False
 
     def __enter__(self):
         return self

--- a/locopy/s3.py
+++ b/locopy/s3.py
@@ -98,27 +98,31 @@ class S3(Cmd):
         If kms_key Defaults to ``None`` then the AES256 ServerSideEncryption
         will be used.
 
-    dbapi : DBAPI 2 module
+    dbapi : DBAPI 2 module, optional
         A PostgreSQL database adapter which is Python DB API 2.0 compliant
         (``psycopg2``, ``pg8000``, etc.)
 
-    host : str
+    host : str, optional
         Host name of the Redshift cluster to connect to.
 
-    port : int
+    port : int, optional
         Port which connection will be made to Redshift.
 
-    dbname : str
+    dbname : str, optional
         Redshift database name.
 
-    user : str
+    user : str, optional
         Redshift users username.
 
-    password : str
+    password : str, optional
         Redshift users password.
 
-    config_yaml : str
+    config_yaml : str, optional
         String representing the file location of the credentials.
+
+    s3_only : bool, optional
+        If True then do not initialize the underlying redshift connection. It will
+        allow users whom want to soley interact with S3 to use that functionality.
 
 
     Attributes
@@ -137,14 +141,17 @@ class S3(Cmd):
     """
     def __init__(
         self, profile=None, kms_key=None, dbapi=None, host=None, port=None,
-        dbname=None, user=None, password=None, config_yaml=None, **kwargs):
+        dbname=None, user=None, password=None, config_yaml=None, s3_only=False, **kwargs):
 
         self.profile = profile
         self.kms_key = kms_key
         self.session = None
         self.s3 = None
-        super(S3, self).__init__(
-            dbapi, host, port, dbname, user, password, config_yaml)
+
+        if not s3_only:
+            super(S3, self).__init__(
+                dbapi, host, port, dbname, user, password, config_yaml)
+
         self._set_session()
         self._set_client()
 

--- a/locopy/s3.py
+++ b/locopy/s3.py
@@ -122,7 +122,7 @@ class S3(Cmd):
 
     s3_only : bool, optional
         If ``True`` then do not initialize the underlying redshift connection. It will
-        allow users whom want to soley interact with S3 to use that functionality.
+        allow users who want to soley interact with S3 to use that functionality.
 
 
     Attributes

--- a/locopy/s3.py
+++ b/locopy/s3.py
@@ -121,7 +121,7 @@ class S3(Cmd):
         String representing the file location of the credentials.
 
     s3_only : bool, optional
-        If True then do not initialize the underlying redshift connection. It will
+        If ``True`` then do not initialize the underlying redshift connection. It will
         allow users whom want to soley interact with S3 to use that functionality.
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,3 +95,16 @@ def test_s3_upload_download_file(s3_bucket, dbapi):
 
     assert filecmp.cmp(LOCAL_FILE, LOCAL_FILE_DL)
     os.remove(LOCAL_FILE_DL)
+
+
+@pytest.mark.integration
+def test_s3_only_upload_download_file(s3_bucket):
+
+    with locopy.S3(profile=CREDS_DICT['profile'], s3_only=True) as s3:
+        s3.upload_to_s3(LOCAL_FILE, S3_BUCKET, "myfile.txt")
+
+    with locopy.S3(profile=CREDS_DICT['profile'], s3_only=True) as s3:
+        s3.download_from_s3(S3_BUCKET, "myfile.txt", LOCAL_FILE_DL)
+
+    assert filecmp.cmp(LOCAL_FILE, LOCAL_FILE_DL)
+    os.remove(LOCAL_FILE_DL)

--- a/tests/test_locopy.py
+++ b/tests/test_locopy.py
@@ -143,6 +143,11 @@ def test_is_connected(rs_creds, dbapi):
         test_redshift = locopy.Cmd(dbapi=dbapi, **rs_creds)
     assert test_redshift._is_connected() is True
 
+    # throws exception in _is_connected
+    test_redshift = CmdNoConnect(**rs_creds)
+    del test_redshift.conn
+    assert test_redshift._is_connected() is False
+
 
 
 @pytest.mark.parametrize('dbapi', DBAPIS)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -304,6 +304,21 @@ def test_super_init_yaml(mock_session, dbapi):
 
 
 
+@pytest.mark.parametrize('dbapi', DBAPIS)
+@mock.patch('locopy.utility.open', mock.mock_open(read_data=GOOD_CONFIG_YAML))
+@mock.patch('locopy.s3.Session')
+def test_super_init_s3_only(mock_session, dbapi):
+    s = locopy.S3(dbapi=dbapi, config_yaml='MY_YAML_FILE.yml', s3_only=True)
+    assert hasattr(s, 'host') == False
+    assert hasattr(s, 'port') == False
+    assert hasattr(s, 'dbname') == False
+    assert hasattr(s, 'user') == False
+    assert hasattr(s, 'password') == False
+    assert s._is_connected() == False
+
+
+
+
 @mock.patch('locopy.s3.Session.get_credentials')
 def test_get_profile_tokens(mock_cred, aws_creds):
     r = MockS3()


### PR DESCRIPTION
@theianrobertson wondering if you can take a look. 

Funnily enough @ian-whitestone had requested this feature a while back. He wanted to just use the S3 functionality to move data to S3 and back, and **not always** have to provide redshift credentials. This should solve for this by having a extra flag which people can turn on when using `S3` and it will bypass the `Cmd.__init__` 

Open to alternative ways, but this seems fairly simple for now.