### PR TITLE
updating pyyaml to fix #25

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 boto3==1.7.21
 psycopg2-binary==2.7.4
 pg8000==1.12.1
-PyYAML==3.12
+PyYAML==4.2b4
 Sphinx==1.7.4
 sphinx-rtd-theme==0.3.1
 pytest==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.7.21
-PyYAML==3.12
+PyYAML==4.2b4
 pandas>=0.19.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author_email="faisal.dosani@capitalone.com",
     license="Apache Software License",
     packages=["locopy"],
-    install_requires=["boto3==1.7.21", "PyYAML==3.12", "pandas>=0.19.0"],
+    install_requires=["boto3==1.7.21", "PyYAML==4.2b4", "pandas>=0.19.0"],
     extras_require={"psycopg2": ["psycopg2-binary==2.7.4"], "pg8000": ["pg8000==1.12.1"]},
     zip_safe=False,
 )


### PR DESCRIPTION
@theianrobertson do you mind reviewing this?

- Essentially there is a venerability with `pyyaml`. See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18342
- going from `3.12` to `4.2b4` provides a fix. 
- we are only using `pyyaml` for reading in configs so there shouldn't be any particular regressions
  - unit and integration tests are working good
- will pin to a more stable version down the road once `4.2` is officially released. 