### PR TITLE
Sphinx default fix

### DIFF
--- a/locopy/s3.py
+++ b/locopy/s3.py
@@ -281,7 +281,7 @@ class S3(object):
             logger.error("Error downloading from S3. err: %s", e)
             raise S3DownloadError("Error downloading from S3.")
 
-    def download_list_from_s3(self, s3_list, local_path=os.getcwd()):
+    def download_list_from_s3(self, s3_list, local_path=None):
         """
         Download a list of files from s3.
 
@@ -299,6 +299,9 @@ class S3(object):
         list
             Returns a list of strings of the local file names
         """
+        if local_path is None:
+            local_path = os.getcwd()
+
         output = []
         for f in s3_list:
             s3_bucket, key = self.parse_s3_url(f)

--- a/locopy/snowflake.py
+++ b/locopy/snowflake.py
@@ -167,7 +167,7 @@ class Snowflake(S3, Database):
             )
         )
 
-    def download_from_internal(self, stage, local=os.getcwd(), parallel=10):
+    def download_from_internal(self, stage, local=None, parallel=10):
         """
         Download file(s) from a internal stage via the ``GET`` command.
 
@@ -183,6 +183,9 @@ class Snowflake(S3, Database):
         parallel : int, optional
             Specifies the number of threads to use for downloading files.
         """
+        if local is None:
+            local = os.getcwd()
+
         self.execute("GET {0} file://{1} PARALLEL={2}".format(stage, local, parallel))
 
     def copy(

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -136,9 +136,9 @@ def test_upload_to_internal(mock_session, sf_credentials):
                 "PUT file:///some/file @~/internal PARALLEL=99 AUTO_COMPRESS=False", None
             )
 
-            sf.upload_to_internal("C:\some\file", "@~/internal")
+            sf.upload_to_internal(r"C:\some\file", "@~/internal")
             sf.conn.cursor.return_value.execute.assert_called_with(
-                "PUT file://C:\some\file @~/internal PARALLEL=4 AUTO_COMPRESS=True", None
+                r"PUT file://C:\some\file @~/internal PARALLEL=4 AUTO_COMPRESS=True", None
             )
 
             # exception
@@ -161,9 +161,9 @@ def test_download_from_internal(mock_session, sf_credentials):
                 "GET @~/internal file:///some/file PARALLEL=99", None
             )
 
-            sf.download_from_internal("@~/internal", "C:\some\file")
+            sf.download_from_internal("@~/internal", r"C:\some\file")
             sf.conn.cursor.return_value.execute.assert_called_with(
-                "GET @~/internal file://C:\some\file PARALLEL=10", None
+                r"GET @~/internal file://C:\some\file PARALLEL=10", None
             )
 
             # exception


### PR DESCRIPTION
- Fixes #36 
- Seems like a few warnings in the tests popped up with regards to `\s`. Making them raw suppresses the warnings from `pytest` runs