### PR TITLE
Additonal sf file type support

### DIFF
--- a/docs/source/snowflake.rst
+++ b/docs/source/snowflake.rst
@@ -15,7 +15,7 @@ Upload to internal stage and run COPY into table command with YAML
     with locopy.Snowflake(dbapi=snowflake.connector, config_yaml="example.yaml") as sf:
         sf.execute(create_sql)
         sf.upload_to_internal("example_data.csv", "@~/internal_stage")
-        sf.copy("namespace.table", "@~/internal_stage/example_data.csv.gz", delim=",")
+        sf.copy("namespace.table", "@~/internal_stage/example_data.csv.gz")
         sf.execute("SELECT * FROM namespace.table")
         res = sf.cursor.fetchall()
     print(res)
@@ -67,8 +67,8 @@ The  ``format_options`` and ``copy_options`` allow for adding additional paramet
     sf.copy(
       "namespace.table",
       "@~/internal_stage/example_data.csv.gz",
-      delim=",",
-      format_options=["TRIM_SPACE = TRUE"],
+      file_type="csv",
+      format_options=["FIELD_DELIMITER=','", "TRIM_SPACE = TRUE"],
       copy_options=["FORCE = TRUE", "PURGE = TRUE"])
 
 These extra options will allow you to customize the COPY process to: trim spaces, force load, and

--- a/tests/data/mock_file.json
+++ b/tests/data/mock_file.json
@@ -1,0 +1,27 @@
+{
+    "location": {
+      "city": "Lexington",
+      "zip": "40503",
+      },
+      "sq__ft": "1000",
+      "sale_date": "4-25-16",
+      "price": "75836"
+},
+{
+    "location": {
+      "city": "Belmont",
+      "zip": "02478",
+      },
+      "sq__ft": "1103",
+      "sale_date": "6-18-16",
+      "price": "92567"
+}
+{
+    "location": {
+      "city": "Winchester",
+      "zip": "01890",
+      },
+      "sq__ft": "1122",
+      "sale_date": "1-31-16",
+      "price": "89921"
+}

--- a/tests/test_integration_sf.py
+++ b/tests/test_integration_sf.py
@@ -119,7 +119,6 @@ def test_copy(dbapi):
         test.copy(
             "locopy_integration_testing",
             "@~/staged/mock_file.txt.gz",
-            delim="|",
             copy_options=["PURGE = TRUE"],
         )
         test.execute("SELECT * FROM locopy_integration_testing ORDER BY id")

--- a/tests/test_integration_sf.py
+++ b/tests/test_integration_sf.py
@@ -38,6 +38,7 @@ INTEGRATION_CREDS = str(Path.home()) + os.sep + ".locopy-sfrc"
 S3_BUCKET = "locopy-integration-testing"
 CURR_DIR = os.path.dirname(os.path.abspath(__file__))
 LOCAL_FILE = os.path.join(CURR_DIR, "data", "mock_file.txt")
+LOCAL_FILE_JSON = os.path.join(CURR_DIR, "data", "mock_file.json")
 LOCAL_FILE_DL = os.path.join(CURR_DIR, "data", "mock_file_dl.txt")
 
 CREDS_DICT = locopy.utility.read_config_yaml(INTEGRATION_CREDS)
@@ -114,7 +115,7 @@ def test_copy(dbapi):
         test.upload_to_internal(LOCAL_FILE, "@~/staged/")
         test.execute("USE SCHEMA {}".format(CREDS_DICT["schema"]))
         test.execute(
-            "CREATE TEMPORARY TABLE locopy_integration_testing (id INTEGER, variable VARCHAR(20))"
+            "CREATE OR REPLACE TEMPORARY TABLE locopy_integration_testing (id INTEGER, variable VARCHAR(20))"
         )
         test.copy(
             "locopy_integration_testing",
@@ -129,6 +130,38 @@ def test_copy(dbapi):
             (2, "This is liné 2"),
             (3, "This is line 3"),
             (4, "This is lïne 4"),
+        ]
+
+        for i, result in enumerate(results):
+            assert result[0] == expected[i][0]
+            assert result[1] == expected[i][1]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("dbapi", DBAPIS)
+def test_copy_json(dbapi):
+
+    with locopy.Snowflake(dbapi=dbapi, **CREDS_DICT) as test:
+        test.upload_to_internal(LOCAL_FILE_JSON, "@~/staged/")
+        test.execute("USE SCHEMA {}".format(CREDS_DICT["schema"]))
+        test.execute(
+            "CREATE OR REPLACE TEMPORARY TABLE locopy_integration_testing (variable VARIANT)"
+        )
+        test.copy(
+            "locopy_integration_testing",
+            "@~/staged/mock_file.json.gz",
+            file_type="json",
+            copy_options=["PURGE = TRUE"],
+        )
+        test.execute(
+            "SELECT variable:location:city, variable:price FROM locopy_integration_testing ORDER BY variable"
+        )
+        results = test.cursor.fetchall()
+
+        expected = [
+            ('"Belmont"', '"92567"'),
+            ('"Lexington"', '"75836"'),
+            ('"Winchester"', '"89921"'),
         ]
 
         for i, result in enumerate(results):

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -188,30 +188,57 @@ def test_download_from_internal_windows(mock_session, sf_credentials):
             )
 
 
+@pytest.mark.parametrize(
+    "file_type, format_options, copy_options, expected",
+    [
+        ("csv", None, None, "(TYPE='csv' FIELD_DELIMITER='|' SKIP_HEADER=0) "),
+        (
+            "csv",
+            ["FIELD_DELIMITER=','", "SKIP_HEADER=1"],
+            None,
+            "(TYPE='csv' FIELD_DELIMITER=',' SKIP_HEADER=1) ",
+        ),
+        (
+            "csv",
+            ["FIELD_DELIMITER='|'", "SKIP_HEADER=0", "a=1", "b=2"],
+            ["c=3", "d=4"],
+            "(TYPE='csv' FIELD_DELIMITER='|' SKIP_HEADER=0 a=1 b=2) c=3 d=4",
+        ),
+        ("parquet", None, None, "(TYPE='parquet' ) "),
+        (
+            "parquet",
+            ["BINARY_AS_TEXT=FALSE"],
+            ["c=3", "d=4"],
+            "(TYPE='parquet' BINARY_AS_TEXT=FALSE) c=3 d=4",
+        ),
+        ("json", None, None, "(TYPE='json' ) "),
+        ("json", ["COMPRESSION=GZIP"], ["c=3", "d=4"], "(TYPE='json' COMPRESSION=GZIP) c=3 d=4"),
+    ],
+)
 @mock.patch("locopy.s3.Session")
-def test_copy(mock_session, sf_credentials):
+def test_copy(mock_session, file_type, format_options, copy_options, expected, sf_credentials):
     with mock.patch("snowflake.connector.connect") as mock_connect:
         with Snowflake(profile=PROFILE, dbapi=DBAPIS, **sf_credentials) as sf:
 
-            sf.copy("table_name", "@~/stage")
-            sf.conn.cursor.return_value.execute.assert_called_with(
-                "COPY INTO table_name FROM '@~/stage' FILE_FORMAT = (TYPE='csv' FIELD_DELIMITER='|' SKIP_HEADER=0 ) ",
-                None,
-            )
-
-            sf.copy("table_name", "@~/stage", delim=",", header=True)
-            sf.conn.cursor.return_value.execute.assert_called_with(
-                "COPY INTO table_name FROM '@~/stage' FILE_FORMAT = (TYPE='csv' FIELD_DELIMITER=',' SKIP_HEADER=1 ) ",
-                None,
-            )
-
             sf.copy(
-                "table_name", "@~/stage", format_options=["a=1", "b=2"], copy_options=["c=3", "d=4"]
+                "table_name",
+                "@~/stage",
+                file_type=file_type,
+                format_options=format_options,
+                copy_options=copy_options,
             )
             sf.conn.cursor.return_value.execute.assert_called_with(
-                "COPY INTO table_name FROM '@~/stage' FILE_FORMAT = (TYPE='csv' FIELD_DELIMITER='|' SKIP_HEADER=0 a=1 b=2) c=3 d=4",
-                None,
+                "COPY INTO table_name FROM '@~/stage' FILE_FORMAT = {0}".format(expected), None
             )
+
+
+@mock.patch("locopy.s3.Session")
+def test_copy_exception(mock_session, sf_credentials):
+    with mock.patch("snowflake.connector.connect") as mock_connect:
+        with Snowflake(profile=PROFILE, dbapi=DBAPIS, **sf_credentials) as sf:
+
+            with pytest.raises(ValueError):
+                sf.copy("table_name", "@~/stage", file_type="unknown")
 
             # exception
             sf.conn.cursor.return_value.execute.side_effect = Exception("COPY Exception")
@@ -223,30 +250,69 @@ def test_copy(mock_session, sf_credentials):
                 sf.copy("table_name", "@~/stage")
 
 
+@pytest.mark.parametrize(
+    "file_type, format_options, header, copy_options, expected",
+    [
+        ("csv", None, False, None, "(TYPE='csv' FIELD_DELIMITER='|') HEADER=False "),
+        (
+            "csv",
+            ["FIELD_DELIMITER=','"],
+            True,
+            None,
+            "(TYPE='csv' FIELD_DELIMITER=',') HEADER=True ",
+        ),
+        (
+            "csv",
+            ["FIELD_DELIMITER=','", "a=1", "b=2"],
+            True,
+            ["c=3", "d=4"],
+            "(TYPE='csv' FIELD_DELIMITER=',' a=1 b=2) HEADER=True c=3 d=4",
+        ),
+        ("parquet", None, False, None, "(TYPE='parquet' ) HEADER=False "),
+        (
+            "parquet",
+            ["SNAPPY_COMPRESSION=FALSE"],
+            False,
+            ["c=3", "d=4"],
+            "(TYPE='parquet' SNAPPY_COMPRESSION=FALSE) HEADER=False c=3 d=4",
+        ),
+        ("json", None, False, None, "(TYPE='json' ) HEADER=False "),
+        (
+            "json",
+            ["COMPRESSION=GZIP"],
+            False,
+            ["c=3", "d=4"],
+            "(TYPE='json' COMPRESSION=GZIP) HEADER=False c=3 d=4",
+        ),
+    ],
+)
 @mock.patch("locopy.s3.Session")
-def test_unload(mock_session, sf_credentials):
+def test_unload(
+    mock_session, file_type, format_options, header, copy_options, expected, sf_credentials
+):
     with mock.patch("snowflake.connector.connect") as mock_connect:
         with Snowflake(profile=PROFILE, dbapi=DBAPIS, **sf_credentials) as sf:
 
-            sf.unload("@~/stage", "table_name")
-            sf.conn.cursor.return_value.execute.assert_called_with(
-                "COPY INTO @~/stage FROM table_name FILE_FORMAT = (TYPE='csv' FIELD_DELIMITER='|' ) HEADER=False ",
-                None,
-            )
-
-            sf.unload("@~/stage", "table_name", delim=",", header=True)
-            sf.conn.cursor.return_value.execute.assert_called_with(
-                "COPY INTO @~/stage FROM table_name FILE_FORMAT = (TYPE='csv' FIELD_DELIMITER=',' ) HEADER=True ",
-                None,
-            )
-
             sf.unload(
-                "@~/stage", "table_name", format_options=["a=1", "b=2"], copy_options=["c=3", "d=4"]
+                "@~/stage",
+                "table_name",
+                file_type=file_type,
+                format_options=format_options,
+                header=header,
+                copy_options=copy_options,
             )
             sf.conn.cursor.return_value.execute.assert_called_with(
-                "COPY INTO @~/stage FROM table_name FILE_FORMAT = (TYPE='csv' FIELD_DELIMITER='|' a=1 b=2) HEADER=False c=3 d=4",
-                None,
+                "COPY INTO @~/stage FROM table_name FILE_FORMAT = {0}".format(expected), None
             )
+
+
+@mock.patch("locopy.s3.Session")
+def test_unload_exception(mock_session, sf_credentials):
+    with mock.patch("snowflake.connector.connect") as mock_connect:
+        with Snowflake(profile=PROFILE, dbapi=DBAPIS, **sf_credentials) as sf:
+
+            with pytest.raises(ValueError):
+                sf.unload("table_name", "@~/stage", file_type="unknown")
 
             # exception
             sf.conn.cursor.return_value.execute.side_effect = Exception("UNLOAD Exception")


### PR DESCRIPTION
@theianrobertson If you have a chance to take a peek
This should close #38 

- small tweaks to `GET` and `PUT` to use `PurePath`.
- removing hardened use of `csv` only. Now supports `csv`, `json`, and `parquet`
  - one note is there is no explicit validation of `format_options` which is still just a list of strings as before. (ex: `["FIELD_DELIMITER=','", "TRIM_SPACE = TRUE"]`)
- The `copy` and `unload` methods have a slightly different signatures as we aren't always assuming csv formatting