### PR TITLE
switch logging to Loguru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 #Mac
 .DS_Store
+
+# from pip install -e .
+pip-wheel-metadata/

--- a/locopy/database.py
+++ b/locopy/database.py
@@ -18,11 +18,9 @@
 """
 import time
 
-from .logger import get_logger, DEBUG, INFO, WARN, ERROR, CRITICAL
+from .logger import logger
 from .errors import CredentialsError, DBError
 from .utility import read_config_yaml
-
-logger = get_logger(__name__, INFO)
 
 
 class Database(object):
@@ -89,7 +87,7 @@ class Database(object):
             self.conn = self.dbapi.connect(**self.connection)
             self.cursor = self.conn.cursor()
         except Exception as e:
-            logger.error("Error connecting to the database. err: %s", e)
+            logger.error("Error connecting to the database. err: {err}", err=e)
             raise DBError("Error connecting to the database.")
 
     def _disconnect(self):
@@ -107,7 +105,7 @@ class Database(object):
                 self.cursor.close()
                 self.conn.close()
             except Exception as e:
-                logger.error("Error disconnecting from the database. err: %s", e)
+                logger.error("Error disconnecting from the database. err: {err}", err=e)
                 raise DBError("There is a problem disconnecting from the database.")
         else:
             logger.info("No connection to close")
@@ -138,11 +136,11 @@ class Database(object):
         """
         if self._is_connected():
             start_time = time.time()
-            logger.info("Running SQL: %s", sql)
+            logger.info("Running SQL: {sql}", sql=sql)
             try:
                 self.cursor.execute(sql, params)
             except Exception as e:
-                logger.error("Error running SQL query. err: %s", e)
+                logger.error("Error running SQL query. err: {err}", err=e)
                 raise DBError("Error running SQL query.")
             if commit:
                 self.conn.commit()
@@ -152,7 +150,7 @@ class Database(object):
             else:
                 time_str = ""
             time_str += str(int(elapsed) % 60) + " seconds"
-            logger.info("Time elapsed: %s", time_str)
+            logger.info("Time elapsed: {time}", time=time_str)
         else:
             raise DBError("Cannot execute SQL on a closed connection.")
 

--- a/locopy/logger.py
+++ b/locopy/logger.py
@@ -17,46 +17,8 @@
 """Logging Module
 Module which setsup the basic logging infrustrcuture for the application
 """
-import logging
 import sys
+from loguru import logger
 
-# logger formating
-BRIEF_FORMAT = "%(levelname)s %(asctime)s - %(name)s: %(message)s"
-VERBOSE_FORMAT = (
-    "%(levelname)s|%(asctime)s|%(name)s|%(filename)s|" "%(funcName)s|%(lineno)d: %(message)s"
-)
-FORMAT_TO_USE = VERBOSE_FORMAT
-
-# logger levels
-DEBUG = logging.DEBUG
-INFO = logging.INFO
-WARN = logging.WARN
-ERROR = logging.ERROR
-CRITICAL = logging.CRITICAL
-
-
-def get_logger(name=None, log_level=logging.DEBUG):
-    """Sets the basic logging features for the application
-
-    Parameters
-    ----------
-    name : str, optional
-        The name of the logger. Defaults to ``None``
-
-    log_level : int, optional
-        The logging level. Defaults to ``logging.INFO``
-
-    Returns
-    -------
-    logging.Logger
-        Returns a Logger obejct which is set with the passed in paramters.
-        Please see the following for more details:
-        https://docs.python.org/2/library/logging.html
-    """
-    logging.basicConfig(format=FORMAT_TO_USE, stream=sys.stdout, level=log_level)
-    logger = logging.getLogger(name)
-    return logger
-
-
-# set the logger for our current dependencies
-logging.getLogger("botocore").setLevel(ERROR)
+logger.remove()
+logger.add(sys.stderr, level="INFO")

--- a/locopy/redshift.py
+++ b/locopy/redshift.py
@@ -20,6 +20,7 @@ to Redshift, and run arbitrary code.
 """
 import os
 
+from .logger import logger
 from .database import Database
 from .s3 import S3
 from .utility import (
@@ -29,10 +30,7 @@ from .utility import (
     write_file,
     concatenate_files,
 )
-from .logger import get_logger, DEBUG, INFO, WARN, ERROR, CRITICAL
 from .errors import CredentialsError, DBError
-
-logger = get_logger(__name__, INFO)
 
 
 def add_default_copy_options(copy_options=None):
@@ -208,7 +206,7 @@ class Redshift(S3, Database):
             self.execute(sql, commit=True)
 
         except Exception as e:
-            logger.error("Error running COPY on Redshift. err: %s", e)
+            logger.error("Error running COPY on Redshift. err: {err}", err=e)
             raise DBError("Error running COPY on Redshift.")
 
     def load_and_copy(
@@ -422,7 +420,7 @@ class Redshift(S3, Database):
             )
             self.execute(sql, commit=True)
         except Exception as e:
-            logger.error("Error running UNLOAD on redshift. err: %s", e)
+            logger.error("Error running UNLOAD on redshift. err: {err}", err=e)
             raise DBError("Error running UNLOAD on redshift.")
 
     def _get_column_names(self, query):

--- a/locopy/snowflake.py
+++ b/locopy/snowflake.py
@@ -22,13 +22,11 @@ import os
 
 from pathlib import PurePath
 from urllib.parse import urlparse
+from .logger import logger
 from .database import Database
 from .s3 import S3
 from .utility import ProgressPercentage, compress_file_list, split_file, write_file
-from .logger import get_logger, DEBUG, INFO, WARN, ERROR, CRITICAL
 from .errors import CredentialsError, DBError, S3CredentialsError
-
-logger = get_logger(__name__, INFO)
 
 
 COPY_FORMAT_OPTIONS = {
@@ -176,8 +174,8 @@ class Snowflake(S3, Database):
         try:
             S3.__init__(self, profile, kms_key)
         except S3CredentialsError:
-            logger.warn("S3 credentials we not found. S3 functionality is disabled")
-            logger.warn("Only internal stages are available")
+            logger.warning("S3 credentials we not found. S3 functionality is disabled")
+            logger.warning("Only internal stages are available")
         Database.__init__(self, dbapi, config_yaml, **kwargs)
 
     def _connect(self):
@@ -297,7 +295,7 @@ class Snowflake(S3, Database):
             self.execute(sql, commit=True)
 
         except Exception as e:
-            logger.error("Error running COPY on Snowflake. err: %s", e)
+            logger.error("Error running COPY on Snowflake. err: {err}", err=e)
             raise DBError("Error running COPY on Snowflake.")
 
     def unload(
@@ -363,5 +361,5 @@ class Snowflake(S3, Database):
             )
             self.execute(sql, commit=True)
         except Exception as e:
-            logger.error("Error running UNLOAD on Snowflake. err: %s", e)
+            logger.error("Error running UNLOAD on Snowflake. err: {err}", err=e)
             raise DBError("Error running UNLOAD on Snowflake.")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ sphinx-rtd-theme==0.4.2
 pytest==4.2.0
 pytest-cov==2.6.1
 pandas>=0.19.0
+loguru==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.9.92
 PyYAML==4.2b4
 pandas>=0.19.0
+loguru==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ CURR_DIR = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(CURR_DIR, "README.rst"), encoding="utf-8") as file_open:
     LONG_DESCRIPTION = file_open.read()
 
+with open(os.path.join(CURR_DIR, "requirements.txt"), encoding="utf-8") as file_open:
+    INSTALL_REQUIRES = file_open.read().split("\n")
+
 exec(open("locopy/_version.py").read())
 
 setup(
@@ -35,7 +38,7 @@ setup(
     author_email="faisal.dosani@capitalone.com",
     license="Apache Software License",
     packages=["locopy"],
-    install_requires=["boto3==1.9.92", "PyYAML==4.2b4", "pandas>=0.19.0"],
+    install_requires=INSTALL_REQUIRES,
     extras_require={
         "psycopg2": ["psycopg2==2.7.7"],
         "pg8000": ["pg8000==1.13.1"],


### PR DESCRIPTION
Closes #41 

- Switching from the standard logging to `loguru`, and associated changes to the actual messages to follow `{}` formatting.
- small tweak to `setup.py` so that it will read `requirements.txt`

@theianrobertson Appreciate your thoughts

