### PR TITLE
Move to latest version of pyyaml and bump patch version

### DIFF
--- a/locopy/_version.py
+++ b/locopy/_version.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.9.92
-PyYAML==4.2b4
+PyYAML>=5.1
 pandas>=0.19.0
 loguru==0.2.5


### PR DESCRIPTION
Should close #43, this just bumps to a later version of PyYaml and changes from a strict version to a minimum version.