### PR TITLE
Adding support for SQLite

### DIFF
--- a/locopy/database.py
+++ b/locopy/database.py
@@ -110,7 +110,7 @@ class Database(object):
         else:
             logger.info("No connection to close")
 
-    def execute(self, sql, commit=True, params=None):
+    def execute(self, sql, commit=True, params=()):
         """Execute some sql against the connection.
 
         Parameters

--- a/locopy/snowflake.py
+++ b/locopy/snowflake.py
@@ -193,6 +193,8 @@ class Snowflake(S3, Database):
             self.execute("USE WAREHOUSE {0}".format(self.connection["warehouse"]))
         if self.connection.get("database") is not None:
             self.execute("USE DATABASE {0}".format(self.connection["database"]))
+        if self.connection.get("schema") is not None:
+            self.execute("USE SCHEMA {0}".format(self.connection["schema"]))
 
     def upload_to_internal(self, local, stage, parallel=4, auto_compress=True):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 boto3==1.9.92
 hypothesis==4.32.2
-psycopg2==2.7.7
-pg8000==1.13.1
-snowflake-connector-python==1.7.6
+psycopg2>=2.7.7
+pg8000>=1.13.1
+snowflake-connector-python>=1.7.6
 PyYAML==4.2b4
 Sphinx==1.8.4
 sphinx-rtd-theme==0.4.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def sf_credentials():
         "account": "account",
         "warehouse": "warehouse",
         "database": "database",
+        "schema": "schema",
         "user": "user",
         "password": "password",
     }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -22,6 +22,7 @@
 
 import pytest
 import mock
+import sqlite3
 import pg8000, psycopg2
 import snowflake.connector
 
@@ -40,7 +41,7 @@ other: stuff
 extra: 123
 another: 321"""
 
-DBAPIS = [pg8000, psycopg2, snowflake.connector]
+DBAPIS = [sqlite3, pg8000, psycopg2, snowflake.connector]
 
 
 @pytest.mark.parametrize("dbapi", DBAPIS)

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -383,7 +383,7 @@ def test_redshiftcopy(mock_session, credentials, dbapi):
                     r.session.get_credentials().secret_key,
                     r.session.get_credentials().token,
                 ),
-                None,
+                (),
             )
         )
 
@@ -400,7 +400,7 @@ def test_redshiftcopy(mock_session, credentials, dbapi):
                     r.session.get_credentials().secret_key,
                     r.session.get_credentials().token,
                 ),
-                None,
+                (),
             )
         )
 
@@ -583,7 +583,7 @@ def test_get_column_names(mock_session, credentials, dbapi):
         r._connect()
         assert r._get_column_names("query") == None
         sql = "SELECT * FROM (query) WHERE 1 = 0"
-        assert mock_connect.return_value.cursor.return_value.execute.called_with(sql, None)
+        assert mock_connect.return_value.cursor.return_value.execute.called_with(sql, ())
 
         mock_connect.return_value.cursor.return_value.description = [["COL1 "], ["COL2 "]]
         r = locopy.Redshift(dbapi=dbapi, **credentials)


### PR DESCRIPTION
In this pull request I have added support for SQLite as well as an additional feature for Snowflake users. If the user supplies `schema` in their credentials, `locopy.snowflake.Snowflake` will run `USE SCHEMA {schema}` for the user.

Fixes #50 
Fixes #55 