### PR TITLE
bump version 0.3.4

### DIFF
--- a/locopy/_version.py
+++ b/locopy/_version.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"


### PR DESCRIPTION
Cutting new release of `locopy` (0.3.4):

- Contains a small bug fix for the snowflake dataframe dtype checking (#64)
- Switched the private connect and disconnect to public. (#63). Allows for more intuitive usages outside the `with` context.