### PR TITLE
bump version 0.3.5

### DIFF
--- a/locopy/_version.py
+++ b/locopy/_version.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"


### PR DESCRIPTION
Cutting new release of locopy (0.3.5):

- Contains a small bug fix for #66 
