### PR TITLE
bump version 0.3.6

### DIFF
--- a/locopy/_version.py
+++ b/locopy/_version.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"


### PR DESCRIPTION
Cutting new release of `locopy` (0.3.6):

- logging typo fix (#70)
- switching back to standard logging (#72) 
- relaxing requirements file ( #74)