### PR TITLE
Add function to insert pandas dataframe to redshift

### DIFF
--- a/locopy/database.py
+++ b/locopy/database.py
@@ -113,7 +113,7 @@ class Database(object):
         else:
             logger.info("No connection to close")
 
-    def execute(self, sql, commit=True, params=(), many=False):
+    def execute(self, sql, commit=True, params=(), many=False, verbose=True):
         """Execute some sql against the connection.
 
         Parameters
@@ -132,6 +132,9 @@ class Database(object):
         many : bool, default False
             Whether to execute the script as an "execute many"
 
+        verbose: bool, default True
+            Whether to print executed query
+
         Raises
         ------
         DBError
@@ -142,7 +145,8 @@ class Database(object):
         """
         if self._is_connected():
             start_time = time.time()
-            logger.info("Running SQL: %s", sql)
+            if verbose:
+                logger.info("Running SQL: %s", sql)
             try:
                 if many:
                     self.cursor.executemany(sql, params)

--- a/locopy/utility.py
+++ b/locopy/utility.py
@@ -255,10 +255,10 @@ def find_column_type(dataframe):
     def validate_date_object(column):
         try:
             pd.to_datetime(column)
-            if re.search(r'\d+:\d+:\d+', column.sample(1).to_string(index=False)):
-                return 'timestamp'
+            if re.search(r"\d+:\d+:\d+", column.sample(1).to_string(index=False)):
+                return "timestamp"
             else:
-                return 'date'
+                return "date"
         except (ValueError, TypeError):
             return None
 
@@ -276,14 +276,14 @@ def find_column_type(dataframe):
         print(data)
         if data.size == 0:
             column_type.append("varchar")
-        elif data.dtype in ['datetime64[ns]', 'M8[ns]']:
+        elif data.dtype in ["datetime64[ns]", "M8[ns]"]:
             column_type.append("timestamp")
-        elif data.dtype=='bool':
+        elif data.dtype == "bool":
             column_type.append("boolean")
         elif str(data.dtype).startswith("object"):
-            data_type =  validate_float_object(data) or validate_date_object(data)
+            data_type = validate_float_object(data) or validate_date_object(data)
             if not data_type:
-                column_type.append('varchar')
+                column_type.append("varchar")
             else:
                 column_type.append(data_type)
         elif str(data.dtype).startswith("int"):
@@ -291,6 +291,7 @@ def find_column_type(dataframe):
         elif str(data.dtype).startswith("float"):
             column_type.append("float")
     return OrderedDict(zip(list(dataframe.columns), column_type))
+
 
 class ProgressPercentage(object):
     """

--- a/locopy/utility.py
+++ b/locopy/utility.py
@@ -249,53 +249,48 @@ def find_column_type(dataframe):
         A dictionary of columns with their data type
     """
     from datetime import datetime, date
+    import pandas as pd
+    import re
 
-    def validate_date(date_text):
+    def validate_date_object(column):
         try:
-            datetime.strptime(date_text, "%Y-%m-%d")
-            return "date"
-        except ValueError:
-            try:
-                datetime.strptime(date_text, "%Y-%m-%d %H:%M:%S")
-                return "timestamp"
-            except ValueError:
-                return None
+            pd.to_datetime(column)
+            if re.search(r'\d+:\d+:\d+', column.sample(1).to_string(index=False)):
+                return 'timestamp'
+            else:
+                return 'date'
+        except (ValueError, TypeError):
+            return None
 
-    def validate_object(text):
+    def validate_float_object(column):
         try:
-            float(text)
+            pd.to_numeric(column)
             return "float"
-        except ValueError:
-            return validate_date(text)
+        except (ValueError, TypeError):
+            return None
 
     column_type = []
     for column in dataframe.columns:
+        print(column)
         data = dataframe[column].dropna().reset_index(drop=True)
+        print(data)
         if data.size == 0:
             column_type.append("varchar")
-        elif isinstance(data[0], datetime):
+        elif data.dtype in ['datetime64[ns]', 'M8[ns]']:
             column_type.append("timestamp")
-        elif isinstance(data[0], date):
-            column_type.append("date")
+        elif data.dtype=='bool':
+            column_type.append("boolean")
         elif str(data.dtype).startswith("object"):
-            date_types = [validate_object(i) for i in data.tolist()]
-            if sum([not i for i in date_types]) == 0:
-                if set(["float"]) == set(date_types):
-                    column_type.append("float")
-                elif set(["timestamp"]) == set(date_types):
-                    column_type.append("timestamp")
-                elif set(["date"]) == set(date_types):
-                    column_type.append("date")
-                else:
-                    column_type.append("varchar")
+            data_type =  validate_float_object(data) or validate_date_object(data)
+            if not data_type:
+                column_type.append('varchar')
             else:
-                column_type.append("varchar")
+                column_type.append(data_type)
         elif str(data.dtype).startswith("int"):
             column_type.append("int")
         elif str(data.dtype).startswith("float"):
             column_type.append("float")
     return OrderedDict(zip(list(dataframe.columns), column_type))
-
 
 class ProgressPercentage(object):
     """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,7 +45,6 @@ TEST_DF_2 = pd.read_csv(os.path.join(CURR_DIR, "data", "mock_dataframe_2.txt"), 
 CREDS_DICT = locopy.utility.read_config_yaml(INTEGRATION_CREDS)
 
 
-
 @pytest.fixture()
 def s3_bucket():
     session = boto3.Session(profile_name=CREDS_DICT["profile"])
@@ -155,6 +154,7 @@ def test_unload(s3_bucket, dbapi):
 
         os.remove(LOCAL_FILE_DL)
 
+
 @pytest.mark.integration
 @pytest.mark.parametrize("dbapi", DBAPIS)
 def test_insert_dataframe_to_table(s3_bucket, dbapi):
@@ -196,7 +196,7 @@ def test_insert_dataframe_to_table(s3_bucket, dbapi):
                 "b": [pd.to_datetime("2013-01-01"), pd.to_datetime("2019-01-01")],
                 "c": [True, False],
                 "d": [Decimal(2), Decimal(3)],
-                "e": [None, "x'y"]
+                "e": [None, "x'y"],
             }
         )
         redshift.insert_dataframe_to_table(TEST_DF_3, "locopy_test_3", create=True)

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -30,6 +30,9 @@ import locopy
 from locopy import Redshift
 from locopy.errors import CredentialsError, DBError
 
+import os
+from collections import OrderedDict
+
 PROFILE = "test"
 GOOD_CONFIG_YAML = """
 host: host
@@ -39,6 +42,7 @@ user: user
 password: password"""
 
 DBAPIS = [pg8000, psycopg2]
+CURR_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_add_default_copy_options():
@@ -621,3 +625,60 @@ def testunload_no_connection(mock_session, credentials, dbapi):
         r.connect()
         with pytest.raises(Exception):
             r.unload("query", "path")
+
+
+@pytest.mark.parametrize("dbapi", DBAPIS)
+@mock.patch("locopy.s3.Session")
+def testinsert_dataframe_to_table(mock_session, credentials, dbapi):
+    import pandas as pd
+
+    test_df = pd.read_csv(os.path.join(CURR_DIR, "data", "mock_dataframe.txt"), sep=",")
+    with mock.patch(dbapi.__name__ + ".connect") as mock_connect:
+        r = locopy.Redshift(dbapi=dbapi, **credentials)
+        r.connect()
+        r.insert_dataframe_to_table(test_df, "database.schema.test")
+        mock_connect.return_value.cursor.return_value.execute.assert_called_with(
+                "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')", ()
+            )
+
+        r.insert_dataframe_to_table(test_df, "database.schema.test", create=True)
+        mock_connect.return_value.cursor.return_value.execute.assert_any_call(
+                "CREATE TABLE database.schema.test (a int,b varchar,c date)", ()
+            )
+        mock_connect.return_value.cursor.return_value.execute.assert_called_with(
+                "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')", ()
+            )
+
+        r.insert_dataframe_to_table(test_df, "database.schema.test", columns=["a", "b"])
+
+        mock_connect.return_value.cursor.return_value.execute.assert_called_with(
+                "INSERT INTO database.schema.test (a,b) VALUES ('1', 'x'), ('2', 'y')", ()
+            )
+
+        r.insert_dataframe_to_table(
+                test_df,
+                "database.schema.test",
+                create=True,
+                metadata=OrderedDict([("col1", "int"), ("col2", "varchar"), ("col3", "date")]),
+            )
+
+        mock_connect.return_value.cursor.return_value.execute.assert_any_call(
+                "CREATE TABLE database.schema.test (col1 int,col2 varchar,col3 date)", ()
+            )
+        mock_connect.return_value.cursor.return_value.execute.assert_called_with(
+                "INSERT INTO database.schema.test (col1,col2,col3) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')", ()
+            )
+
+        r.insert_dataframe_to_table(
+                test_df,
+                "database.schema.test",
+                create=False,
+                batch_size = 1
+        )
+
+        mock_connect.return_value.cursor.return_value.execute.assert_any_call(
+                "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01')", ()
+            )
+        mock_connect.return_value.cursor.return_value.execute.assert_any_call(
+                "INSERT INTO database.schema.test (a,b,c) VALUES ('2', 'y', '2001-04-02')", ()
+            )

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -638,47 +638,45 @@ def testinsert_dataframe_to_table(mock_session, credentials, dbapi):
         r.connect()
         r.insert_dataframe_to_table(test_df, "database.schema.test")
         mock_connect.return_value.cursor.return_value.execute.assert_called_with(
-                "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')", ()
-            )
+            "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')",
+            (),
+        )
 
         r.insert_dataframe_to_table(test_df, "database.schema.test", create=True)
         mock_connect.return_value.cursor.return_value.execute.assert_any_call(
-                "CREATE TABLE database.schema.test (a int,b varchar,c date)", ()
-            )
+            "CREATE TABLE database.schema.test (a int,b varchar,c date)", ()
+        )
         mock_connect.return_value.cursor.return_value.execute.assert_called_with(
-                "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')", ()
-            )
+            "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')",
+            (),
+        )
 
         r.insert_dataframe_to_table(test_df, "database.schema.test", columns=["a", "b"])
 
         mock_connect.return_value.cursor.return_value.execute.assert_called_with(
-                "INSERT INTO database.schema.test (a,b) VALUES ('1', 'x'), ('2', 'y')", ()
-            )
+            "INSERT INTO database.schema.test (a,b) VALUES ('1', 'x'), ('2', 'y')", ()
+        )
 
         r.insert_dataframe_to_table(
-                test_df,
-                "database.schema.test",
-                create=True,
-                metadata=OrderedDict([("col1", "int"), ("col2", "varchar"), ("col3", "date")]),
-            )
-
-        mock_connect.return_value.cursor.return_value.execute.assert_any_call(
-                "CREATE TABLE database.schema.test (col1 int,col2 varchar,col3 date)", ()
-            )
-        mock_connect.return_value.cursor.return_value.execute.assert_called_with(
-                "INSERT INTO database.schema.test (col1,col2,col3) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')", ()
-            )
-
-        r.insert_dataframe_to_table(
-                test_df,
-                "database.schema.test",
-                create=False,
-                batch_size = 1
+            test_df,
+            "database.schema.test",
+            create=True,
+            metadata=OrderedDict([("col1", "int"), ("col2", "varchar"), ("col3", "date")]),
         )
 
         mock_connect.return_value.cursor.return_value.execute.assert_any_call(
-                "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01')", ()
-            )
+            "CREATE TABLE database.schema.test (col1 int,col2 varchar,col3 date)", ()
+        )
+        mock_connect.return_value.cursor.return_value.execute.assert_called_with(
+            "INSERT INTO database.schema.test (col1,col2,col3) VALUES ('1', 'x', '2011-01-01'), ('2', 'y', '2001-04-02')",
+            (),
+        )
+
+        r.insert_dataframe_to_table(test_df, "database.schema.test", create=False, batch_size=1)
+
         mock_connect.return_value.cursor.return_value.execute.assert_any_call(
-                "INSERT INTO database.schema.test (a,b,c) VALUES ('2', 'y', '2001-04-02')", ()
-            )
+            "INSERT INTO database.schema.test (a,b,c) VALUES ('1', 'x', '2011-01-01')", ()
+        )
+        mock_connect.return_value.cursor.return_value.execute.assert_any_call(
+            "INSERT INTO database.schema.test (a,b,c) VALUES ('2', 'y', '2001-04-02')", ()
+        )


### PR DESCRIPTION
Several changes in this commit
1. added boolean type to `find_column_type()` in `utility.py`
2. used pd.to_datetime and pd.to_numeric to stop doing row wise calculation. see details in issue #67 
3. added `insert_dataframe_to_table` to redshift class. 
4. added all relevant testing.  