### PR TITLE
Put overwrite

### DIFF
--- a/locopy/snowflake.py
+++ b/locopy/snowflake.py
@@ -197,7 +197,7 @@ class Snowflake(S3, Database):
         if self.connection.get("schema") is not None:
             self.execute("USE SCHEMA {0}".format(self.connection["schema"]))
 
-    def upload_to_internal(self, local, stage, parallel=4, auto_compress=True):
+    def upload_to_internal(self, local, stage, parallel=4, auto_compress=True, overwrite=True):
         """
         Upload file(s) to a internal stage via the ``PUT`` command.
 
@@ -218,11 +218,16 @@ class Snowflake(S3, Database):
             Specifies if Snowflake uses gzip to compress files during upload.
             If ``True``, the files are compressed (if they are not already compressed).
             if ``False``, the files are uploaded as-is.
+
+        overwrite : bool, optional
+            Specifies whether Snowflake overwrites an existing file with the same name during upload.
+            If ``True``, existing file with the same name is overwritten.
+            if ``False``, existing file with the same name is not overwritten.
         """
         local_uri = PurePath(local).as_posix()
         self.execute(
-            "PUT 'file://{0}' {1} PARALLEL={2} AUTO_COMPRESS={3}".format(
-                local_uri, stage, parallel, auto_compress
+            "PUT 'file://{0}' {1} PARALLEL={2} AUTO_COMPRESS={3} OVERWRITE={4}".format(
+                local_uri, stage, parallel, auto_compress, overwrite
             )
         )
 

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -159,12 +159,20 @@ def test_upload_to_internal(mock_session, sf_credentials):
         with Snowflake(profile=PROFILE, dbapi=DBAPIS, **sf_credentials) as sf:
             sf.upload_to_internal("/some/file", "@~/internal")
             sf.conn.cursor.return_value.execute.assert_called_with(
-                "PUT 'file:///some/file' @~/internal PARALLEL=4 AUTO_COMPRESS=True", ()
+                "PUT 'file:///some/file' @~/internal PARALLEL=4 AUTO_COMPRESS=True OVERWRITE=True",
+                (),
             )
 
             sf.upload_to_internal("/some/file", "@~/internal", parallel=99, auto_compress=False)
             sf.conn.cursor.return_value.execute.assert_called_with(
-                "PUT 'file:///some/file' @~/internal PARALLEL=99 AUTO_COMPRESS=False", ()
+                "PUT 'file:///some/file' @~/internal PARALLEL=99 AUTO_COMPRESS=False OVERWRITE=True",
+                (),
+            )
+
+            sf.upload_to_internal("/some/file", "@~/internal", overwrite=False)
+            sf.conn.cursor.return_value.execute.assert_called_with(
+                "PUT 'file:///some/file' @~/internal PARALLEL=4 AUTO_COMPRESS=True OVERWRITE=False",
+                (),
             )
 
             # exception
@@ -181,7 +189,8 @@ def test_upload_to_internal_windows(mock_session, sf_credentials):
 
             sf.upload_to_internal(r"C:\some\file", "@~/internal")
             sf.conn.cursor.return_value.execute.assert_called_with(
-                "PUT 'file://C:/some/file' @~/internal PARALLEL=4 AUTO_COMPRESS=True", ()
+                "PUT 'file://C:/some/file' @~/internal PARALLEL=4 AUTO_COMPRESS=True OVERWRITE=True",
+                (),
             )
 
 


### PR DESCRIPTION
Fixes #84 

- Fairly simple enhancement to expose the `OVERWRITE` option in the Snowflake `PUT` command when uploading to the internal stage.