### PR TITLE
Ignoreheader fix

### DIFF
--- a/locopy/database.py
+++ b/locopy/database.py
@@ -19,9 +19,8 @@
 import time
 
 from .errors import CredentialsError, DBError
-from .logger import get_logger, INFO
+from .logger import INFO, get_logger
 from .utility import read_config_yaml
-
 
 logger = get_logger(__name__, INFO)
 

--- a/locopy/errors.py
+++ b/locopy/errors.py
@@ -33,6 +33,12 @@ class LocopySplitError(LocopyError):
     """
 
 
+class LocopyIgnoreHeaderError(LocopyError):
+    """
+    Raised when Multiple IGNOREHEADERS are found in copy options.
+    """
+
+
 class LocopyConcatError(LocopyError):
     """
     Raised when there is an error concatenating files.

--- a/locopy/redshift.py
+++ b/locopy/redshift.py
@@ -22,17 +22,16 @@ import os
 
 from .database import Database
 from .errors import DBError
-from .logger import get_logger, INFO
+from .logger import INFO, get_logger
 from .s3 import S3
 from .utility import (
     compress_file_list,
     concatenate_files,
-    split_file,
-    write_file,
     find_column_type,
     get_ignoreheader_number,
+    split_file,
+    write_file,
 )
-
 
 logger = get_logger(__name__, INFO)
 

--- a/locopy/redshift.py
+++ b/locopy/redshift.py
@@ -24,7 +24,14 @@ from .database import Database
 from .errors import DBError
 from .logger import get_logger, INFO
 from .s3 import S3
-from .utility import compress_file_list, concatenate_files, split_file, write_file, find_column_type
+from .utility import (
+    compress_file_list,
+    concatenate_files,
+    split_file,
+    write_file,
+    find_column_type,
+    get_ignoreheader_number,
+)
 
 
 logger = get_logger(__name__, INFO)
@@ -281,7 +288,14 @@ class Redshift(S3, Database):
             copy_options = []
 
         # generate the actual splitting of the files
-        upload_list = split_file(local_file, local_file, splits=splits)
+        # We need to check if IGNOREHEADER is set as this can cause issues.
+        ignore_header = get_ignoreheader_number(copy_options)
+        upload_list = split_file(local_file, local_file, splits=splits, ignore_header=ignore_header)
+
+        if splits > 1 and ignore_header > 0:
+            # remove the IGNOREHEADER from copy_options
+            logger.info("Removing the IGNOREHEADER option as split  column names")
+            copy_options = [i for i in copy_options if not i.startswith("IGNOREHEADER ")]
 
         if compress:
             copy_options.append("GZIP")

--- a/locopy/redshift.py
+++ b/locopy/redshift.py
@@ -293,7 +293,7 @@ class Redshift(S3, Database):
 
         if splits > 1 and ignore_header > 0:
             # remove the IGNOREHEADER from copy_options
-            logger.info("Removing the IGNOREHEADER option as split  column names")
+            logger.info("Removing the IGNOREHEADER option as split is enabled")
             copy_options = [i for i in copy_options if not i.startswith("IGNOREHEADER ")]
 
         if compress:

--- a/locopy/s3.py
+++ b/locopy/s3.py
@@ -32,9 +32,8 @@ from .errors import (
     S3InitializationError,
     S3UploadError,
 )
-from .logger import get_logger, INFO
+from .logger import INFO, get_logger
 from .utility import ProgressPercentage
-
 
 logger = get_logger(__name__, INFO)
 

--- a/locopy/snowflake.py
+++ b/locopy/snowflake.py
@@ -23,10 +23,9 @@ from pathlib import PurePath
 
 from .database import Database
 from .errors import DBError, S3CredentialsError
-from .logger import get_logger, INFO
+from .logger import INFO, get_logger
 from .s3 import S3
 from .utility import find_column_type
-
 
 logger = get_logger(__name__, INFO)
 

--- a/locopy/utility.py
+++ b/locopy/utility.py
@@ -31,10 +31,10 @@ from .errors import (
     CompressionError,
     CredentialsError,
     LocopyConcatError,
-    LocopySplitError,
     LocopyIgnoreHeaderError,
+    LocopySplitError,
 )
-from .logger import get_logger, INFO
+from .logger import INFO, get_logger
 
 logger = get_logger(__name__, INFO)
 

--- a/locopy/utility.py
+++ b/locopy/utility.py
@@ -27,7 +27,13 @@ from itertools import cycle
 
 import yaml
 
-from .errors import CompressionError, CredentialsError, LocopyConcatError, LocopySplitError
+from .errors import (
+    CompressionError,
+    CredentialsError,
+    LocopyConcatError,
+    LocopySplitError,
+    LocopyIgnoreHeaderError,
+)
 from .logger import get_logger, INFO
 
 logger = get_logger(__name__, INFO)
@@ -103,7 +109,7 @@ def compress_file_list(file_list):
     return file_list
 
 
-def split_file(input_file, output_file, splits=1):
+def split_file(input_file, output_file, splits=1, ignore_header=0):
     """Split a file into equal files by lines.
 
     For example: ``myinputfile.txt`` will be split into ``myoutputfile.txt.01``
@@ -119,6 +125,10 @@ def split_file(input_file, output_file, splits=1):
 
     splits : int, optional
         Number of splits to perform. Must be greater than zero. Defaults to 1
+
+    ignore_header : int, optional
+        If ``ignore_header`` is > 0 then that number of rows will be removed from the beginning of
+        the files as they are split. Defaults to 0
 
     Returns
     -------
@@ -145,6 +155,9 @@ def split_file(input_file, output_file, splits=1):
         files = [open("{0}.{1}".format(output_file, x), "wb") for x in pool]
         # open input file and send line to different handler
         with open(input_file, "rb") as f_in:
+            # if we have a value in ignore_header then skip those many lines to start
+            for _ in range(ignore_header):
+                next(f_in)
             for line in f_in:
                 files[next(cpool)].write(line)
         # close file connection
@@ -323,3 +336,32 @@ class ProgressPercentage(object):
                 "\rTransfering [{0}] {1:.2f}%".format("#" * int(percentage / 10), percentage)
             )
             sys.stdout.flush()
+
+
+def get_ignoreheader_number(options):
+    """
+    Return the ``number_rows`` from ``IGNOREHEADER [ AS ] number_rows`` This doesn't not validate
+    that the ``AS`` is valid.
+
+    Parameters
+    ----------
+    options : A list (str) of copy options that should be appended to the COPY
+        statement.
+
+    Returns
+    -------
+    int
+        The ``number_rows`` from ``IGNOREHEADER [ AS ] number_rows``
+
+    Raises
+    ------
+    LocopyIgnoreHeaderError
+        If more than one IGNOREHEADER is found in the options
+    """
+    ignore = [i for i in options if i.startswith("IGNOREHEADER ")]
+    if len(ignore) == 0:
+        return 0
+    elif len(ignore) == 1:
+        return int(ignore[0].strip().split(" ")[-1])
+    else:
+        raise LocopyIgnoreHeaderError("Found more than one IGNOREHEADER in the options")

--- a/tests/data/mock_file_header.txt
+++ b/tests/data/mock_file_header.txt
@@ -1,0 +1,5 @@
+number|line
+1|This iš line 1
+2|This is liné 2
+3|This is line 3
+4|This is lïne 4

--- a/tests/test_redshift.py
+++ b/tests/test_redshift.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
+from collections import OrderedDict
 from unittest import mock
 
 import pg8000
@@ -29,9 +31,6 @@ import pytest
 import locopy
 from locopy import Redshift
 from locopy.errors import CredentialsError, DBError
-
-import os
-from collections import OrderedDict
 
 PROFILE = "test"
 GOOD_CONFIG_YAML = """

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -35,8 +35,8 @@ from locopy.utility import (
     compress_file_list,
     concatenate_files,
     find_column_type,
-    split_file,
     get_ignoreheader_number,
+    split_file,
 )
 
 GOOD_CONFIG_YAML = u"""host: my.redshift.cluster.com

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -29,7 +29,13 @@ from unittest import mock
 import pytest
 
 import locopy.utility as util
-from locopy.errors import CompressionError, CredentialsError, LocopyConcatError, LocopySplitError
+from locopy.errors import (
+    CompressionError,
+    CredentialsError,
+    LocopyConcatError,
+    LocopyIgnoreHeaderError,
+    LocopySplitError,
+)
 from locopy.utility import (
     compress_file,
     compress_file_list,
@@ -388,3 +394,6 @@ def test_get_ignoreheader_number():
         == 0
     )
     assert get_ignoreheader_number([]) == 0
+
+    with pytest.raises(LocopyIgnoreHeaderError):
+        get_ignoreheader_number(["IGNOREHEADER 1", "IGNOREHEADER 99"])

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -36,6 +36,7 @@ from locopy.utility import (
     concatenate_files,
     find_column_type,
     split_file,
+    get_ignoreheader_number,
 )
 
 GOOD_CONFIG_YAML = u"""host: my.redshift.cluster.com
@@ -141,6 +142,46 @@ def test_split_file():
     splits = split_file(input_file, output_file, 5)
     assert splits == expected
     assert compare_file_contents(input_file, expected)
+    cleanup(splits)
+
+
+def test_split_file_header():
+    input_file = "tests/data/mock_file_header.txt"
+    input_file_no_header = "tests/data/mock_file.txt"
+    output_file = "tests/data/mock_output_file_header.txt"
+
+    splits = split_file(input_file, output_file, ignore_header=1)
+    assert splits == [input_file]
+
+    expected = [
+        "tests/data/mock_output_file_header.txt.0",
+        "tests/data/mock_output_file_header.txt.1",
+    ]
+    splits = split_file(input_file, output_file, 2, ignore_header=1)
+    assert splits == expected
+    assert compare_file_contents(input_file_no_header, expected)
+    cleanup(splits)
+
+    expected = [
+        "tests/data/mock_output_file_header.txt.0",
+        "tests/data/mock_output_file_header.txt.1",
+        "tests/data/mock_output_file_header.txt.2",
+    ]
+    splits = split_file(input_file, output_file, 3, ignore_header=1)
+    assert splits == expected
+    assert compare_file_contents(input_file_no_header, expected)
+    cleanup(splits)
+
+    expected = [
+        "tests/data/mock_output_file_header.txt.0",
+        "tests/data/mock_output_file_header.txt.1",
+        "tests/data/mock_output_file_header.txt.2",
+        "tests/data/mock_output_file_header.txt.3",
+        "tests/data/mock_output_file_header.txt.4",
+    ]
+    splits = split_file(input_file, output_file, 5, ignore_header=1)
+    assert splits == expected
+    assert compare_file_contents(input_file_no_header, expected)
     cleanup(splits)
 
 
@@ -273,3 +314,77 @@ def test_find_column_type():
         "k": "float",
     }
     assert find_column_type(input_text) == output_text
+
+
+def test_get_ignoreheader_number():
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER as 1"]
+        )
+        == 1
+    )
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER as 2"]
+        )
+        == 2
+    )
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER as 99"]
+        )
+        == 99
+    )
+
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER 1"]
+        )
+        == 1
+    )
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER 2"]
+        )
+        == 2
+    )
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER 99"]
+        )
+        == 99
+    )
+
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER is 1"]
+        )
+        == 1
+    )
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER is 2"]
+        )
+        == 2
+    )
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADER is 99"]
+        )
+        == 99
+    )
+
+    assert get_ignoreheader_number(["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS"]) == 0
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "IGNOREHEADERAS 2"]
+        )
+        == 0
+    )
+    assert (
+        get_ignoreheader_number(
+            ["DATEFORMAT 'auto'", "COMPUPDATE ON", "TRUNCATECOLUMNS", "SOMETHINGIGNOREHEADER AS 2"]
+        )
+        == 0
+    )
+    assert get_ignoreheader_number([]) == 0


### PR DESCRIPTION
PR to help fix the issue #87 

The intent here is to:
- Look for `IGNOREHEADER` and extract out the number of rows.
- if `IGNOREHEADER` exists and splits > 1 then we remove the headers form the file when we split and remove it from the options and load into RS.

Would like some eyes on this this there is a bit going on. I tried to make some util functions to help break down things a little bit.